### PR TITLE
Feature/theme settings

### DIFF
--- a/LifeBalance/Assets.xcassets/Background.colorset/Contents.json
+++ b/LifeBalance/Assets.xcassets/Background.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF7",
+          "green" : "0xFD",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x1E",
+          "green" : "0x1B",
+          "red" : "0x1A"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/LifeBalance/ContentView.swift
+++ b/LifeBalance/ContentView.swift
@@ -10,12 +10,14 @@ import CoreData
 
 struct ContentView: View {
     @Environment(\.managedObjectContext) private var viewContext
+    @Environment(\.colorScheme) private var systemTheme
     
-    @FetchRequest(
-        sortDescriptors: [NSSortDescriptor(keyPath: \Day.date, ascending: true)],
-        animation: .default)
-    private var days: FetchedResults<Day>
-    
+//    @FetchRequest(
+//        sortDescriptors: [NSSortDescriptor(keyPath: \Day.date, ascending: true)],
+//        animation: .default)
+//    private var days: FetchedResults<Day>
+    @State var themeColor: ColorScheme
+
     var body: some View {
         TabView {
             HomeView()
@@ -33,12 +35,22 @@ struct ContentView: View {
                     Image(systemName: "plus.circle.fill")
                     Text("Add meal")
                 }
-            SettingsView(persistenceController: PersistenceController())
+            SettingsView(persistenceController: PersistenceController(), themeColor: $themeColor)
                 .tabItem() {
                     Image(systemName: "slider.vertical.3")
                     Text("Settings")
                 }
         }
+        .onAppear(perform: {
+            if(!PersistenceController().loadUserSettings().isEmpty){
+                themeColor = PersistenceController().loadUserSettings()[0].theme ? .light : .dark
+            } else {
+                themeColor = systemTheme
+            }
+            
+        })
+        .environment(\.colorScheme, themeColor)
+        .preferredColorScheme(themeColor)
     }
 }
 
@@ -51,6 +63,6 @@ private let itemFormatter: DateFormatter = {
 
 struct ContentView_Previews: PreviewProvider {
     static var previews: some View {
-        ContentView().environment(\.managedObjectContext, PersistenceController.preview.container.viewContext)
+        ContentView(themeColor: .light).environment(\.managedObjectContext, PersistenceController.preview.container.viewContext)
     }
 }

--- a/LifeBalance/LifeBalanceApp.swift
+++ b/LifeBalance/LifeBalanceApp.swift
@@ -12,11 +12,13 @@ struct LifeBalanceApp: App {
     var parser = FoodParser()
     var nutrientsParser = NutrientsParser()
     var healthKit = HealthKit()
+    @Environment(\.colorScheme) private var systemTheme
     
     let persistenceController = PersistenceController.shared
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            ContentView(themeColor: !PersistenceController().loadUserSettings().isEmpty ? PersistenceController().loadUserSettings()[0].theme ? .light : .dark : systemTheme
+            )
                 .environment(\.managedObjectContext, persistenceController.container.viewContext)
                 .environmentObject(parser)
                 .environmentObject(nutrientsParser)

--- a/LifeBalance/Views/DiaryView.swift
+++ b/LifeBalance/Views/DiaryView.swift
@@ -11,9 +11,9 @@ struct DiaryView: View {
     
     @Environment(\.managedObjectContext) private var viewContext
 
-    @FetchRequest(entity: Day.entity(), sortDescriptors: [], predicate: NSPredicate(format: "date != %@", Date() as CVarArg))
-
-    var days: FetchedResults<Day>
+//    @FetchRequest(entity: Day.entity(), sortDescriptors: [], predicate: NSPredicate(format: "date != %@", Date() as CVarArg))
+//
+//    var days: FetchedResults<Day>
     
     @State var progressValue: Float = 0.25
     @State var color = Color.green
@@ -47,14 +47,14 @@ struct DiaryView: View {
                 }
                 .offset(y: -60)
                 .padding(.leading, 28)
-                ForEach(days) { day in
-                    if (itemFormatter.string(from: day.date) == itemFormatter.string(from: Date())) {
-                        NavigationLink(destination: AddMealView(), label: {
-                            MealCard(meal: day.meal, food: ["Oatmeal", "cottage-cheese"], amount: ["400g", "200g"], backgroundColor: day.meal == "Breakfast" ? Color.gray : Color.green)
-                        })
-                    }
-                }
-                .offset(y: -60)
+//                ForEach(days) { day in
+//                    if (itemFormatter.string(from: day.date) == itemFormatter.string(from: Date())) {
+//                        NavigationLink(destination: AddMealView(), label: {
+//                            MealCard(meal: day.meal, food: ["Oatmeal", "cottage-cheese"], amount: ["400g", "200g"], backgroundColor: day.meal == "Breakfast" ? Color.gray : Color.green)
+//                        })
+//                    }
+//                }
+//                .offset(y: -60)
             }
         }
     }
@@ -64,7 +64,6 @@ struct DiaryView: View {
 struct DiaryView_Previews: PreviewProvider {
     static var previews: some View {
         DiaryView()
-            .preferredColorScheme(.dark)
     }
 }
 

--- a/LifeBalance/Views/SettingsView.swift
+++ b/LifeBalance/Views/SettingsView.swift
@@ -12,9 +12,7 @@ struct SettingsView: View {
     let persistenceController: PersistenceController
      
     @State private var uSettings: [UserSettings] = [UserSettings]()
-    
-    @State private var needsRefresh: Bool = false
-    
+        
     @State private var isSaved = false
     
     let referenceValues = ReferenceValues()
@@ -34,6 +32,7 @@ struct SettingsView: View {
     @State private var selectedFrameworkIndexAge = ""
     
     @State private var lightMode = true
+    @Binding var themeColor: ColorScheme
         
     func updateSettings() {
         if(!isSaved){
@@ -60,12 +59,12 @@ struct SettingsView: View {
             }
             uSettings[0].theme = lightMode
             persistenceController.updateUserSettings()
-            needsRefresh.toggle()
         }
         loadSettings()
     }
     
     func loadSettings() {
+        
         uSettings = persistenceController.loadUserSettings()
         if(!uSettings.isEmpty){
             isSaved = true
@@ -91,6 +90,8 @@ struct SettingsView: View {
             lightMode = uSettings[0].theme
             
             referenceValues.getReferenceValues(height: uSettings[0].height ?? "", weight: uSettings[0].weight ?? "", age: uSettings[0].age ?? "", gender: uSettings[0].gender ?? "", activity: uSettings[0].activityLevel ?? "")
+        }else {
+            lightMode = themeColor == .light ? true : false
         }
     }
     
@@ -99,6 +100,7 @@ struct SettingsView: View {
             Form{
                 Section(header: Text("Display")){
                     Toggle("Lightmode", isOn: $lightMode).onChange(of: lightMode){value in
+                        themeColor = value ? .light : .dark // This gets the theme changed, BUT after changing theme you can't change it again or edit any other settings.
                         updateSettings()
                     }
                 }
@@ -145,8 +147,7 @@ struct SettingsView: View {
                             updateSettings()
                         }
                     }
-                }/*accentcolor used only to "activate" needsRefresh*/
-                .accentColor(needsRefresh ? .blue: .blue)
+                }
                 
                 Text("Required calories intake: \(referenceValues.calories, specifier: "%.2f") kcal")
                 Text("Required iron intake: \(referenceValues.iron, specifier: "%.2f") mg")
@@ -156,13 +157,13 @@ struct SettingsView: View {
             .onAppear(perform: {
                 loadSettings()
             })
-            
         }
     }
 }
 
 struct SettingsView_Previews: PreviewProvider {
     static var previews: some View {
-        SettingsView(persistenceController: PersistenceController())
+        
+        SettingsView(persistenceController: PersistenceController(), themeColor: .constant(.dark))
     }
 }

--- a/LifeBalance/Views/SettingsView.swift
+++ b/LifeBalance/Views/SettingsView.swift
@@ -20,9 +20,9 @@ struct SettingsView: View {
     let referenceValues = ReferenceValues()
     
     var genders = ["Male", "Female", "Undefined"]
-    var weight = ["80", "81", "82", "83", "84", "85"]
-    var height = ["180", "181", "182", "183", "184", "185"]
-    var age = ["20","21","22","23","24"]
+    var weight = (40...160).map{"\($0)"}
+    var height = (140...210).map{"\($0)"}
+    var age = (15...80).map{"\($0)"}
     var activitylevel = ["Very active", "Active", "Moderately active", "Lightly active", "Sedentary"]
     var target = ["Weight loss", "Muscle gain", "Healthy lifestyle", "Staying alive"]
     
@@ -34,6 +34,36 @@ struct SettingsView: View {
     @State private var selectedFrameworkIndexAge = ""
     
     @State private var lightMode = true
+        
+    func updateSettings() {
+        if(!isSaved){
+            persistenceController.saveUserSettings(gender: selectedFrameworkIndexGender, height: selectedFrameworkIndexHeight, weight: selectedFrameworkIndexWeight, theme: lightMode,
+                                                activityLevel: selectedFrameworkIndexActivity, target: selectedFrameworkIndexTarget, age: selectedFrameworkIndexAge)
+        } else {
+            if(!selectedFrameworkIndexGender.isEmpty){
+                uSettings[0].gender = selectedFrameworkIndexGender
+            }
+            if(!selectedFrameworkIndexHeight.isEmpty){
+                uSettings[0].height = selectedFrameworkIndexHeight
+            }
+            if(!selectedFrameworkIndexWeight.isEmpty) {
+                uSettings[0].weight = selectedFrameworkIndexWeight
+            }
+            if(!selectedFrameworkIndexTarget.isEmpty) {
+                uSettings[0].target = selectedFrameworkIndexTarget
+            }
+            if(!selectedFrameworkIndexActivity.isEmpty) {
+                uSettings[0].activityLevel = selectedFrameworkIndexActivity
+            }
+            if(!selectedFrameworkIndexAge.isEmpty) {
+                uSettings[0].age = selectedFrameworkIndexAge
+            }
+            uSettings[0].theme = lightMode
+            persistenceController.updateUserSettings()
+            needsRefresh.toggle()
+        }
+        loadSettings()
+    }
     
     func loadSettings() {
         uSettings = persistenceController.loadUserSettings()
@@ -57,6 +87,9 @@ struct SettingsView: View {
             if(selectedFrameworkIndexAge == "") {
                 selectedFrameworkIndexAge = uSettings[0].age ?? ""
             }
+            
+            lightMode = uSettings[0].theme
+            
             referenceValues.getReferenceValues(height: uSettings[0].height ?? "", weight: uSettings[0].weight ?? "", age: uSettings[0].age ?? "", gender: uSettings[0].gender ?? "", activity: uSettings[0].activityLevel ?? "")
         }
     }
@@ -65,76 +98,52 @@ struct SettingsView: View {
         NavigationView {
             Form{
                 Section(header: Text("Display")){
-                    Toggle(isOn: $lightMode, label: {
-                        Text("Light mode")
-                    })
+                    Toggle("Lightmode", isOn: $lightMode).onChange(of: lightMode){value in
+                        updateSettings()
+                    }
                 }
                 Section(header: Text("Your info"), footer: Text("We use this data to calculate the correct daily intakes")){
                     Picker(selection: $selectedFrameworkIndexWeight, label: Text("Weight")) {
                         ForEach(weight, id: \.self) {
                             Text($0)
+                        }.onChange(of: selectedFrameworkIndexWeight){value in
+                            updateSettings()
                         }
                     }
                     Picker(selection: $selectedFrameworkIndexHeight, label: Text("Height")) {
                         ForEach(height, id: \.self) {
                             Text($0)
+                        }.onChange(of: selectedFrameworkIndexHeight){value in
+                            updateSettings()
                         }
                     }
                     Picker(selection: $selectedFrameworkIndexGender, label: Text("Gender")) {
                         ForEach(genders, id: \.self) {
                             Text($0)
+                        }.onChange(of: selectedFrameworkIndexGender){value in
+                            updateSettings()
                         }
                     }
                     Picker(selection: $selectedFrameworkIndexAge, label: Text("Age")) {
                         ForEach(age, id: \.self) {
                             Text($0)
+                        }.onChange(of: selectedFrameworkIndexAge){value in
+                            updateSettings()
                         }
                     }
                     Picker(selection: $selectedFrameworkIndexActivity, label: Text("Acitivity level")) {
                         ForEach(activitylevel, id: \.self) {
                             Text($0)
+                        }.onChange(of: selectedFrameworkIndexActivity){value in
+                            updateSettings()
                         }
                     }
                     Picker(selection: $selectedFrameworkIndexTarget, label: Text("Target")) {
                         ForEach(target, id: \.self) {
                             Text($0)
+                        }.onChange(of: selectedFrameworkIndexTarget){value in
+                            updateSettings()
                         }
-                    }
-                    Button(action: {
-                        if(!isSaved){
-                            persistenceController.saveUserSettings(gender: selectedFrameworkIndexGender, height: selectedFrameworkIndexHeight, weight: selectedFrameworkIndexWeight, theme: lightMode,
-                                                                activityLevel: selectedFrameworkIndexActivity, target: selectedFrameworkIndexTarget, age: selectedFrameworkIndexAge)
-                        } else {
-                            if(!selectedFrameworkIndexGender.isEmpty){
-                                uSettings[0].gender = selectedFrameworkIndexGender
-                            }
-                            if(!selectedFrameworkIndexHeight.isEmpty){
-                                uSettings[0].height = selectedFrameworkIndexHeight
-                            }
-                            if(!selectedFrameworkIndexWeight.isEmpty) {
-                                uSettings[0].weight = selectedFrameworkIndexWeight
-                            }
-                            if(!selectedFrameworkIndexTarget.isEmpty) {
-                                uSettings[0].target = selectedFrameworkIndexTarget
-                            }
-                            if(!selectedFrameworkIndexActivity.isEmpty) {
-                                uSettings[0].activityLevel = selectedFrameworkIndexActivity
-                            }
-                            if(!selectedFrameworkIndexAge.isEmpty) {
-                                uSettings[0].age = selectedFrameworkIndexAge
-                            }
-                            persistenceController.updateUserSettings()
-                            needsRefresh.toggle()
-                        }
-                        loadSettings()
-                    }) {
-                        if(!isSaved){
-                            Text("Save").font(.body)
-                        } else {
-                            Text("Update")
-                                .font(.body)
-                        }
-                        
                     }
                 }/*accentcolor used only to "activate" needsRefresh*/
                 .accentColor(needsRefresh ? .blue: .blue)


### PR DESCRIPTION
Theme settings working now, so that first time you open app up, it recognises the system theme and uses that. Settings view also updating automatically when changing values, so you won't have to press save.
Commented the few DAY fetchrequests away, since they kept popping up with errors.
Commit has a BUG:
Go to settings
Change theme
Change theme again or try to change weight/age/etc.
CRASH

reason for this is this line in the code: themeColor = lightMode ? ColorScheme.light : .dark
Since it updates the state of themecolor and maybe then on the background opening something double, so that it has some module twice or something.

Right now you can go to settings change other data how much you want, and you can change theme once, then you have to change view to home/etc. and then come back to settings and you can change other settings or theme again.