### PR TITLE
Bug fix for navigation when pressing add meal in home page.

### DIFF
--- a/LifeBalance.xcodeproj/project.pbxproj
+++ b/LifeBalance.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		82F432BF274E38AA005CD4BB /* HealthKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 82F432BE274E38AA005CD4BB /* HealthKit.framework */; };
 		9675E1C4274A66EF0013D6FB /* NutritionalDatalistView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9675E1C3274A66EF0013D6FB /* NutritionalDatalistView.swift */; };
 		9675E1C6274A6A080013D6FB /* NutritionDatalistItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9675E1C5274A6A080013D6FB /* NutritionDatalistItem.swift */; };
+		96F87D972758EED300C5536E /* TabController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96F87D962758EED300C5536E /* TabController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -120,6 +121,7 @@
 		82F432BE274E38AA005CD4BB /* HealthKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = HealthKit.framework; path = System/Library/Frameworks/HealthKit.framework; sourceTree = SDKROOT; };
 		9675E1C3274A66EF0013D6FB /* NutritionalDatalistView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NutritionalDatalistView.swift; sourceTree = "<group>"; };
 		9675E1C5274A6A080013D6FB /* NutritionDatalistItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NutritionDatalistItem.swift; sourceTree = "<group>"; };
+		96F87D962758EED300C5536E /* TabController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -182,6 +184,7 @@
 		5F8AB6F8274278E300A59F43 /* LifeBalance */ = {
 			isa = PBXGroup;
 			children = (
+				96F87D952758EEBC00C5536E /* Controllers */,
 				8240118E2754F21C003CD870 /* CoreDataModels */,
 				820232B1274E5024007F386D /* Info.plist */,
 				82F432BC274E38AA005CD4BB /* LifeBalance.entitlements */,
@@ -297,6 +300,14 @@
 				82F432BE274E38AA005CD4BB /* HealthKit.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		96F87D952758EEBC00C5536E /* Controllers */ = {
+			isa = PBXGroup;
+			children = (
+				96F87D962758EED300C5536E /* TabController.swift */,
+			);
+			path = Controllers;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -446,6 +457,7 @@
 				5FEAEC5A274C153B002DE8E2 /* FoodParserDataModels.swift in Sources */,
 				6A61DA4E2750F9D60083BB46 /* ReferenceValues.swift in Sources */,
 				5F0069B42753D778001F54FD /* FoodRow.swift in Sources */,
+				96F87D972758EED300C5536E /* TabController.swift in Sources */,
 				82D93AEB274BAF4D00530651 /* AddMealView.swift in Sources */,
 				82F081FE2756087700059481 /* Day+CoreDataProperties.swift in Sources */,
 				5F8AB6FA274278E300A59F43 /* LifeBalanceApp.swift in Sources */,

--- a/LifeBalance/ContentView.swift
+++ b/LifeBalance/ContentView.swift
@@ -17,30 +17,36 @@ struct ContentView: View {
 //        animation: .default)
 //    private var days: FetchedResults<Day>
     @State var themeColor: ColorScheme
+    @StateObject private var tabController = TabController()
 
     var body: some View {
-        TabView {
+        TabView(selection: $tabController.activeTab) {
             HomeView(persistenceController: PersistenceController())
+                .tag(Tab.home)
                 .tabItem() {
                     Image(systemName: "heart.fill")
                     Text("Home")
                 }
             DiaryView(persistenceController: PersistenceController())
+                .tag(Tab.diary)
                 .tabItem() {
                     Image(systemName: "book.fill")
                     Text("Diary")
                 }
             AddMealView(persistenceController: PersistenceController())
+                .tag(Tab.addMeal)
                 .tabItem() {
                     Image(systemName: "plus.circle.fill")
                     Text("Add meal")
                 }
             SettingsView(persistenceController: PersistenceController(), themeColor: $themeColor)
+                .tag(Tab.settings)
                 .tabItem() {
                     Image(systemName: "slider.vertical.3")
                     Text("Settings")
                 }
         }
+        .environmentObject(tabController)
         .onAppear(perform: {
             if(!PersistenceController().loadUserSettings().isEmpty){
                 themeColor = PersistenceController().loadUserSettings()[0].theme ? .light : .dark

--- a/LifeBalance/Controllers/TabController.swift
+++ b/LifeBalance/Controllers/TabController.swift
@@ -1,0 +1,23 @@
+//
+//  TabController.swift
+//  LifeBalance
+//
+//  Created by Jaani Kaukonen on 2.12.2021.
+//
+
+import SwiftUI
+
+enum Tab {
+    case home
+    case diary
+    case addMeal
+    case settings
+}
+
+class TabController: ObservableObject {
+    @Published var activeTab = Tab.home
+
+    func open(_ tab: Tab) {
+        activeTab = tab
+    }
+}

--- a/LifeBalance/Views/AddMealView.swift
+++ b/LifeBalance/Views/AddMealView.swift
@@ -14,6 +14,7 @@ struct AddMealView: View {
     @State private var selectedMealIndex = 0
     @State var addedFoods: [FoodModel] = []
     @State var mealEntities: [Meals] = []
+    @EnvironmentObject private var tabController: TabController
 
     
     var meals = ["Breakfast", "Lunch", "Dinner", "Snack"]

--- a/LifeBalance/Views/HomeView.swift
+++ b/LifeBalance/Views/HomeView.swift
@@ -12,6 +12,7 @@ struct HomeView: View {
     @State var color = Color.green
     @EnvironmentObject var healthKit: HealthKit
     let persistenceController: PersistenceController
+    @EnvironmentObject private var tabController: TabController
         
     var body: some View {
         NavigationView {
@@ -32,7 +33,10 @@ struct HomeView: View {
                                 .cornerRadius(20)
                         }
                     })
-                    NavigationLink(destination: AddMealView(persistenceController: PersistenceController()), label: {
+                    Button(action: {
+                        tabController.open(.addMeal)
+                        
+                    }) {
                         Text("Add new meal")
                             .font(.largeTitle)
                             .bold()
@@ -41,7 +45,8 @@ struct HomeView: View {
                             .background(Color.green)
                             .foregroundColor(.white)
                             .cornerRadius(20)
-                    })
+                    }
+                    
                 }
                 .offset(y: -60)
                 VStack {


### PR DESCRIPTION
### Issue
* Press Add Meal button on home page.
* When Add Meal page loads, navigate to another page from bottom navigation bar.
* Navigate back to Home page from bottom navigation bar.

See how `Home` from bottom navigation bar takes you to `Add meal` view. This is not intended and may cause confusion among users.

### Solution
* Create `Controllers` folder with `TabController.swift`.
* Create enums for selectable tags and TabController class.
* Add selection to TabView that get its value from TabController -> activeTab.
* Create EnvironmentObject for Tabview and add tags to tabItems in `ContentView`.
* In `HomeView`, change the add meal from navigation link to button and call TabController to switch tabs.

Now `Add meal` button from Home page will navigate to `AddMealView` instead of creating a new add meal view on top of home view.
