### PR TITLE
Bugs/daily progress meals

### DIFF
--- a/LifeBalance/Cards/MealCard.swift
+++ b/LifeBalance/Cards/MealCard.swift
@@ -31,7 +31,6 @@ struct MealCard: View {
             .padding(20)
         }
         .frame(width: 350, height: 125, alignment: .leading)
-        .onAppear(perform: {print("\(food.count)")})
     }
 
 }

--- a/LifeBalance/Views/AddMealView.swift
+++ b/LifeBalance/Views/AddMealView.swift
@@ -15,10 +15,10 @@ struct AddMealView: View {
     @State var addedFoods: [FoodModel] = []
     @State var mealEntities: [Meals] = []
     @EnvironmentObject private var tabController: TabController
-
     
     var meals = ["Breakfast", "Lunch", "Dinner", "Snack"]
     let persistenceController: PersistenceController
+    let today = itemFormatter.string(from: Date())
     
     
     var body: some View {
@@ -67,7 +67,7 @@ struct AddMealView: View {
                         }
                     }
                 }.onAppear(perform: {
-                    mealEntities = persistenceController.loadMealEntities(persistenceController.getToday())})
+                    mealEntities = persistenceController.loadMealEntities(persistenceController.getDay(dateToCheck: today))})
         }
     }
 }

--- a/LifeBalance/Views/DiaryView.swift
+++ b/LifeBalance/Views/DiaryView.swift
@@ -17,6 +17,8 @@ struct DiaryView: View {
     @State var color3 = Color.orange
     @State var color4 = Color.red
     
+    let today = itemFormatter.string(from: Date())
+    
     var body: some View {
         NavigationView {
             ScrollView{
@@ -46,7 +48,7 @@ struct DiaryView: View {
                     }
                     .offset(y: -60)
                     .padding(.leading, 28)
-                    let meals = persistenceController.loadMealEntities(persistenceController.getToday())
+                    let meals = persistenceController.loadMealEntities(persistenceController.getDay(dateToCheck: today))
                     ForEach(meals) {meal in
                         let ingr = (meal.ingredients?.allObjects as! [Ingredient])
                         MealCard(meal: meal.mealType ?? "", food: ingr, backgroundColor: Color.green)
@@ -55,13 +57,13 @@ struct DiaryView: View {
                 }
             }
         }
-        .onAppear(perform: {getProgressValue()})
+        .onAppear(perform: getProgressValueToday)
     }
     
-    func getProgressValue() {
+    func getProgressValueToday() {
         // A dummy list for future reference for controlling what is shown on Daily Progress View
         let userSetNutritionalValues = ["calories", "iron"]
-        progressValues = persistenceController.getProgressValues(userSetNutritionalValues: userSetNutritionalValues)
+        progressValues = persistenceController.getProgressValues(userSetNutritionalValues: userSetNutritionalValues, date: today)
     }
 }
 

--- a/LifeBalance/Views/HomeView.swift
+++ b/LifeBalance/Views/HomeView.swift
@@ -13,6 +13,7 @@ struct HomeView: View {
     @EnvironmentObject var healthKit: HealthKit
     let persistenceController: PersistenceController
     @EnvironmentObject private var tabController: TabController
+    let today = itemFormatter.string(from: Date())
         
     var body: some View {
         NavigationView {
@@ -81,13 +82,19 @@ struct HomeView: View {
         }
         .onAppear(perform: healthKit.authorizeHealthStore)
         .onAppear(perform: persistenceController.createRefValuesEntity)
-        .onAppear(perform: {getProgressValue()})
+        .onAppear(perform: {persistenceController.addDay(date: today)})
+        .onAppear(perform: getProgressValueToday)
     }
     
-    func getProgressValue() {
+    func getProgressValueToday() {
+        // anotherDate can be used to scope around different days by variating the "value: _"
+        // Insert anotherDateString to getProgressValues parameter instead of today to switch day
+        // let anotherDate = Calendar.current.date(byAdding: .day, value: -1, to: Date())!
+        // let anotherDateString = itemFormatter.string(from: anotherDate)
+        
         // A dummy list for future reference for controlling what is shown on Daily Progress View
         let userSetNutritionalValues = ["calories", "iron"]
-        progressValues = persistenceController.getProgressValues(userSetNutritionalValues: userSetNutritionalValues)
+        progressValues = persistenceController.getProgressValues(userSetNutritionalValues: userSetNutritionalValues, date: anotherDateString)
     }
 }
 

--- a/LifeBalance/Views/HomeView.swift
+++ b/LifeBalance/Views/HomeView.swift
@@ -94,7 +94,7 @@ struct HomeView: View {
         
         // A dummy list for future reference for controlling what is shown on Daily Progress View
         let userSetNutritionalValues = ["calories", "iron"]
-        progressValues = persistenceController.getProgressValues(userSetNutritionalValues: userSetNutritionalValues, date: anotherDateString)
+        progressValues = persistenceController.getProgressValues(userSetNutritionalValues: userSetNutritionalValues, date: today)
     }
 }
 


### PR DESCRIPTION
Fixed a bug relating the displayed meals on daily progress and diary view. Previous main had an issue when day had changed and no meals were added to new day as the application showed last days meals instead of empty progress values

Solutions:

- Added a day entity if it didn't exist when launched
- Fixed functions in Persistence to work based on a given day so different days can be displayed
- Added a comment to HomeView function getProgressValuesToday() for a logic to switch between days